### PR TITLE
have to revert for now

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -32,7 +32,7 @@ repository:
   has_downloads: false
 
   # Updates the default branch for this repository.
-  default_branch: main
+  default_branch: master
 
 # Labels: define labels for Issues and Pull Requests
 labels:


### PR DESCRIPTION
## Context 📙

PR templates are no longer appearing with it set as main

We will need to investigate why this happened and find a fix

Even after renaming branches or having existing default branches as main, it doesn't show PR templates for them

## Types of changes 🚀

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue) 🐛
- [ ] New feature (non-breaking change which adds functionality) 🔥
- [ ] Breaking change (fix or feature that would cause existing functionality to change) ⚠️
- [ ] Other (Provide a brief description below) ❓

## How Has This Been Tested? 📝

<!--- Test coverage / Manual test -->

- [ ] Unit tests 🧪
- [x] E2E tests 🛫🛬
- [ ] Other (Provide a brief description below) ❓

## Checklist ✅

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation if/where required. 👍
- [ ] I have added tests to cover my changes. 🛠️
- [x] All new and existing tests passed. 💯
- [x] No high or critical vulnerabilities detected. 🌈
