### PR TITLE
feat: Setting repo to public via probot.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -32,7 +32,7 @@ repository:
   has_downloads: false
 
   # Updates the default branch for this repository.
-  default_branch: master
+  default_branch: main
 
 # Labels: define labels for Issues and Pull Requests
 labels:


### PR DESCRIPTION
## Context 📙

Seems at some point probot has sprung to life and evaluated the private setting on this repo which breaks it (see [Community Health Docs](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file)). This sets the value in `settings.yaml` to make the repo public.

## Types of changes 🚀

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue) 🐛
- [x] New feature (non-breaking change which adds functionality) 🔥
- [ ] Breaking change (fix or feature that would cause existing functionality to change) ⚠️
- [ ] Other (Provide a brief description below) ❓

## Related Issue 🔗

<!--- JIRA ticket link  -->

[JIRA: XXXX](<JIRA-URL>)

## How Has This Been Tested? 📝

<!--- Test coverage / Manual test -->

- [ ] Unit tests 🧪
- [ ] E2E tests 🛫🛬
- [ ] Other (Provide a brief description below) ❓

## Screenshots (if appropriate) 📷

## Checklist ✅

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation if/where required. 👍
- [ ] I have added tests to cover my changes. 🛠️
- [ ] All new and existing tests passed. 💯
- [ ] No high or critical vulnerabilities detected. 🌈
