### PR TITLE
fix: add URL to JIRA with placeholder JIRA ID on the Related Issue section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 
 <!--- JIRA ticket link  -->
 
-[JIRA: XXXX](<JIRA-URL>)
+[JIRA: XX-YYYY](https://dyedurham.atlassian.net/browse/XX-YYYY)
 
 ## How Has This Been Tested? 📝
 


### PR DESCRIPTION
## Context 📙

<!--- Why is this change required? What problem does it solve? -->

slightly less friction on filling in PR descriptions, since having to copy/paste the entire URL every time feels less productive than just re-filling the ticket number, which should already be on hand.

## Types of changes 🚀

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue) 🐛
- [X] New feature (non-breaking change which adds functionality) 🔥
- [ ] Breaking change (fix or feature that would cause existing functionality to change) ⚠️
- [ ] Other (Provide a brief description below) ❓

## Related Issue 🔗

<!--- JIRA ticket link  -->

[JIRA: XXXX](<JIRA-URL>)

## How Has This Been Tested? 📝

<!--- Test coverage / Manual test -->

- [ ] Unit tests 🧪
- [ ] E2E tests 🛫🛬
- [ ] Other (Provide a brief description below) ❓

## Screenshots (if appropriate) 📷

## Checklist ✅

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation if/where required. 👍
- [ ] I have added tests to cover my changes. 🛠️
- [ ] All new and existing tests passed. 💯
- [ ] No high or critical vulnerabilities detected. 🌈
